### PR TITLE
Fix coordinate rescaling in LandmarkVisualizationMatplotlib

### DIFF
--- a/utils/landmark/visualization/landmark_visualization_matplotlib.py
+++ b/utils/landmark/visualization/landmark_visualization_matplotlib.py
@@ -70,7 +70,7 @@ class LandmarkVisualizationMatplotlib(LandmarkVisualizationBase):
         """
         coords = landmark.coords
         if self.spacing is not None:
-            coords = coords / self.spacing
+            coords = [c / s for c, s in zip(coords, self.spacing)]
         p = mpatches.Circle((coords[0], coords[1]), self.radius, facecolor=[c / 255.0 for c in color], edgecolor=None)
         image_canvas.add_patch(p)
         if annotation is not None:


### PR DESCRIPTION
Hi,

I was running into the following error message when running the VerSe2020 model:

> File "/MedicalDataAugmentationTool/utils/landmark/visualization/landmark_visualization_matplotlib.py", line 73, in visualize_landmark
> coords = coords / self.spacing
> TypeError: unsupported operand type(s) for /: 'list' and 'list'

Seems like it can happen that both `coords` and `self.spacing` are list objects, and then dividing them does not work as it would if one of them was a numpy array.

It works when replacing this line with elementwise division.